### PR TITLE
Massive improvements (#12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "json-2-csv": "^5.5.1",
         "knex": "^3.1.0",
         "libphonenumber-js": "^1.10.60",
-        "openai": "^4.24.3",
+        "openai": "^4.47.1",
         "pdf-parse": "^1.1.1",
         "redis": "^4.6.13",
         "tedious": "^18.2.0",
@@ -5003,9 +5003,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.37.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.37.1.tgz",
-      "integrity": "sha512-YVuhylpDeTNCWgsfhZe38+c4dDWZuW9VgzNY/sdYiNt6K9pvijroyYENp8YGEUHnuIAKtsLneZX9Qb/iB5XHkw==",
+      "version": "4.47.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.47.1.tgz",
+      "integrity": "sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "json-2-csv": "^5.5.1",
     "knex": "^3.1.0",
     "libphonenumber-js": "^1.10.60",
-    "openai": "^4.24.3",
+    "openai": "^4.47.1",
     "pdf-parse": "^1.1.1",
     "redis": "^4.6.13",
     "tedious": "^18.2.0",

--- a/src/config/openai.ts
+++ b/src/config/openai.ts
@@ -1,0 +1,7 @@
+export default {
+  token: process.env.DISCORD_TOKEN,
+  clientId: process.env.DISCORD_APPLICATION_ID,
+  guildId: process.env.DISCORD_SERVER_ID,
+  channelId: process.env.DISCORD_CHANNEL_ID,
+  botUserId: process.env.DISCORD_BOT_USER_ID
+}

--- a/src/config/openai.ts
+++ b/src/config/openai.ts
@@ -1,7 +1,6 @@
 export default {
-  token: process.env.DISCORD_TOKEN,
-  clientId: process.env.DISCORD_APPLICATION_ID,
-  guildId: process.env.DISCORD_SERVER_ID,
-  channelId: process.env.DISCORD_CHANNEL_ID,
-  botUserId: process.env.DISCORD_BOT_USER_ID
+  openai_api_key: process.env.OPENAI_API_KEY,
+  openai_organization_id: process.env.OPENAI_ORGANIZATION_ID,
+  organization: process.env['OPENAI_ORGANIZATION_ID'],
+  apiKey: process.env['OPENAI_API_KEY'], // This is the default and can be omitted
 }

--- a/src/lib/resultToCsv.ts
+++ b/src/lib/resultToCsv.ts
@@ -1,17 +1,11 @@
-import { createObjectCsvStringifier } from 'csv-writer'
+import { json2csv } from 'json-2-csv'
 
 export const resultToCsv = (result: Array<Record<string, any>>) => {
   if (result.length === 0) {
     return ''
   }
 
-  const keys = Object.keys(result[0])
-  const header = keys.map((key) => ({ id: key, title: key }))
-  const csvStringifier = createObjectCsvStringifier({
-    header,
+  return json2csv(result, {
+    useDateIso8601Format: true
   })
-
-  return (
-    csvStringifier.getHeaderString() + csvStringifier.stringifyRecords(result)
-  )
 }

--- a/src/prompts/answerQuestion.ts
+++ b/src/prompts/answerQuestion.ts
@@ -15,10 +15,21 @@ Denna data blev resultatet
 ${data}
 \`\`\`
 
-Svara på frågan!
-Svara kort och koncist på frågan, helst med max 2 meningar.
+Försök svara på frågan!
+Svara kort och koncist på frågan, helst med max 2-4 meningar.
 Skriv kort, koncist och exakt. Svara alltid på svenska. Nämn inte "kundtjänst"
 eller "kundtjänstmedarbetare". ANVÄND DATA OVAN!!
+
+Om datan är bättre att representera i en tabell, så skriv den i detta format:
+
+\`\`\`
+| Kolumnnamn1 | Kolumnnamn2 | Kolumnnamn3 |
+|-------------|-------------|-------------|
+| Värde1      | Värde2      | Värde3      |
+| Värde4      | Värde5      | Värde6      |
+\`\`\`
+
+När du svarat på frågan, fundera på om det finns en följdfråga som kan vara relevant och erbjud dig att svara på den.
 `
 
 export default prompt

--- a/src/prompts/generateCustomerInfoSQL.ts
+++ b/src/prompts/generateCustomerInfoSQL.ts
@@ -3,17 +3,20 @@ const sqlPrompt = (brokenSql, sqlError) => {
 I have a few internal systems that I need to query for an internal customer
 service bot. The bot gathers relevant information about a customer ahead of
 a call. These are some examples of the tables. Please return with a joined
-query that fetches most relevant information from each table for a given phone
-number.
+query that fetches most relevant information from each table for a given facility id (strAnlnr)
 
 Parameter name is "strAnlnr" in the facilities table. This is the same as the
 "strAnlnr" in the customer_events table. Put the value of strAnlnr in the
 T-SQL query as a parameter.
 
+Equally named columns should be joinable across tables.
+
+You can check what tariffs exist by selecting strTaxekod & strTaxebenamning from tbFuTaxa
+
 Reply in a JSON structure with the T-SQL query  that fetches the relevant information. It is very
 important that your response only includes the valid T-SQL, no comments or other text.
 Do not create aliases for columns, MAKE THE T-SQL AS SHORT AS POSSIBLE.
-Do not list unneccesary columns, only the ones needed!
+Do not list unneccesary columns, only the ones needed. Use up to 5 columns in the select statement, never more!
 
 To return less data, consider doing count and aggregation queries, and only return the most relevant data.
 
@@ -23,6 +26,8 @@ The reply JSON structure should look like this:
   "sql": "SELECT ... FROM ... WHERE ... f.strAnlnr='@strAnlnr' ...;",
 }
 \`\`\`
+
+To identify a customer or facility, you only need strAnlnr as a parameter in the query, adresses, names et.c. are redundant.
 
 
 IMPORTANT! Do not rename fields! They have to be exactly the same as in the examples below!
@@ -273,6 +278,103 @@ CREATE TABLE tbFuAnlaggning (
 	CONSTRAINT PKtbFuAnlaggning PRIMARY KEY (strAnlnr)
 );
 
+CREATE TABLE tbFuFaktura (
+	intRecnum int IDENTITY(1,1),
+	lngFakturanr bigint,
+	intKundnr int,
+	intSpecialAdressnr int,
+	strSeparatAnlnr varchar(15)
+	strForstaAnlnr varchar(15)
+	strFakturaEfternamn1 varchar(40)
+	strFakturaFornamn1 varchar(40)
+	strFakturaEfternamn2 varchar(40)
+	strFakturaFornamn2 varchar(40)
+	strFakturaAdressGata varchar(40)
+	intFakturaAdressnr int,
+	strFakturaAdressbokstav varchar(20)
+	strPostnr varchar(8)
+	strOrt varchar(60)
+	strLandkod char(2)
+	strDistributionssatt char(4)
+	strFakturasortering varchar(2)
+	strBetalningssatt char(4)
+	strBetalstatus char(4)
+	strKravstatus char(4)
+	strAvskrivningsstatus char(4)
+	bolReglerad bit,
+	bytFakturaex tinyint,
+	curBruttobelopp decimal(12,2),
+	curNettobelopp decimal(12,2),
+	decOresavrundning decimal(9,2),
+	curRenhbelopp decimal(12,2),
+	curKvarAttBetala decimal(12,2),
+	datFakturadatum smalldatetime,
+	datForfallodatum smalldatetime,
+	datAnstandTom smalldatetime,
+	datPaminnelsedatum smalldatetime,
+	datInkassodatum smalldatetime,
+	datAvstangningsdatum smalldatetime,
+	datBetalningsforelaggandedatum smalldatetime,
+	datLangtidsbevakningsdatum smalldatetime,
+	datUtskriven smalldatetime,
+	datBokforingsdatum smalldatetime,
+	datSenKravBetDatum smalldatetime,
+	bolInternfaktura bit,
+	bolFlyttfaktura bit,
+	bolFrifaktura bit,
+	bolRantefaktura bit,
+	bolOrdinariefaktura bit,
+	bolForseningsAvgiftFaktura bit,
+	curPaminnelseavgift decimal(12,2),
+	strAnteckning varchar(1000),
+	strKundtext varchar(1000),
+	datAvstangningshotdatum smalldatetime,
+	datOppningsdatum smalldatetime,
+	bolAtgardstackningsaknas bit,
+	strFakturaKundReferens varchar(60),
+	curMoms decimal(12,2),
+	strFakturaVarReferens varchar(100),
+	datAutogirofildatum smalldatetime,
+	datAutogirofildatumAnnullerad smalldatetime,
+	datExternreskontradatum smalldatetime,
+	datExternreskontradatumAnnullerad smalldatetime,
+	datReskontraSkapaddatum smalldatetime,
+	strFakturagrupp varchar(6),
+	strOCRnr varchar(20),
+	datEfakturafildatum smalldatetime,
+	bolStoppaUtskrift bit,
+	strBetalningsforelaggandeAvser varchar(30),
+	datSkapad datetime,
+	intSkapadAv int,
+	strValutakod char(3),
+	bolArkiverad bit,
+	strVarReferensKod varchar(10),
+	curPaminnelseavgiftAvskriven decimal(12,2),
+	curPaminnelseavgiftOverford decimal(12,2),
+	bolPaminnelseavgiftPaPaminnelse bit,
+	strBilagor varchar(50),
+	datFlyttDatum smalldatetime,
+	strFakturagruppering varchar(50),
+	bolEjArkiveradIEDPArkiv bit,
+	datFakturaAndelSkapaddatum smalldatetime,
+	bolSidbrytPerAnlaggning bit,
+	strKravText varchar(200),
+	bolTvingaUtInkasso bit,
+	strArendenrUtslagsnr varchar(30),
+	bolAnnulleradMedNyFaktura bit,
+	lngSkapadAvAnnulleradFakturanr bigint,
+	strUrsprung varchar(20),
+	strRegistratorLoginID varchar(10),
+	strFakturaExtra1 varchar(100),
+	strFakturaExtra2 varchar(100),
+	strFakturaExtra3 varchar(100),
+	strFakturaExtra4 varchar(100),
+	strMomsregnr varchar(14),
+);
+
+
+\`\`\`
+
 Here are som examples of validated SQL Queries:
 
 Question 1:
@@ -337,7 +439,108 @@ FROM vwHandelse H
 JOIN vwKomplettFastighetsBeteckning KF ON KF.strAnlnr=H.strAnlnr
 JOIN tbFuTaxa TA ON TA.strTaxekod=H.strTaxekod AND TA.strDelProdukt in ('HUSH','MAT')
 WHERE H.strAnlnr='2034052452';
-\`\`\`
+
+Tables and Fields
+tbFuHandelse
+This table seems to record events or transactions related to facilities. Key fields include:
+
+recHandelse (int): Primary key, unique identifier for each event.
+intKundnr (int): Customer number, linking the event to a customer.
+strAnlnr (varchar): Facility number, linking the event to a facility.
+intTjanstnr (int): Service number, indicating the type of service.
+datDatumFrom and datDatumTom (datetime): Start and end dates of the event.
+strTaxekod (varchar): Tariff code, linking to the tariff table.
+lngFakturanr (bigint): Invoice number, linking the event to an invoice.
+Various other fields related to the event details, such as strRFID, strFordon, strAvvikelsekod, and strHandelseText.
+tbFuRenhAvvikelse
+This table records deviations or issues related to events.
+
+intRecnum (int): Primary key, unique identifier for each deviation.
+strAvvikelsekod (varchar): Deviation code, primary key.
+strAvvikelsetext (varchar): Text describing the deviation.
+Various boolean fields indicating different statuses and actions related to the deviation.
+tbFuTaxa
+This table contains tariff or pricing information.
+
+intRecnum (int): Primary key, unique identifier for each tariff.
+strTaxekod (varchar): Tariff code, primary key.
+strTaxebenamning (varchar): Tariff name.
+Various fields related to pricing, grouping, and applicability of the tariff.
+tbFuAnlaggning
+This table contains information about facilities.
+
+intRecnum (int): Primary key, unique identifier for each facility.
+strAnlnr (varchar): Facility number, primary key.
+intKundnr (int): Customer number, linking the facility to a customer.
+Various fields related to the address, categorization, and additional details of the facility.
+Relationships
+tbFuHandelse references tbFuAnlaggning through strAnlnr.
+tbFuHandelse references tbFuTaxa through strTaxekod.
+tbFuHandelse references tbFuRenhAvvikelse through strAvvikelsekod.
+Key Insights
+Facility Management: The tbFuAnlaggning table holds details about each facility, which are linked to events in tbFuHandelse.
+Event Tracking: The tbFuHandelse table is central to tracking all events, services, and transactions for each facility.
+Deviations Handling: The tbFuRenhAvvikelse table helps manage and document any issues or deviations related to events.
+Tariff Management: The tbFuTaxa table provides detailed tariff information, crucial for billing and pricing.
+
+Database Structure Analysis for tbFuTaxa
+
+The tbFuTaxa table in the provided database contains the following fields:
+
+strTaxekod:
+Description: This field likely represents the unique code or identifier for each tax type or service fee.
+Data Type: String
+Purpose: It serves as the primary key or unique identifier for each record in the table. It helps in distinguishing different types of taxes or service fees.
+strTaxebenamning:
+Description: This field describes the name or the details of the tax or service fee.
+Data Type: String
+Purpose: It provides a descriptive name for each tax type or service fee, allowing users to understand the nature of the fee or tax.
+Insights and Observations:
+
+Diversity of Tax Codes:
+
+The table contains a wide range of tax codes (e.g., 0001, 0002, 1101, 1201, 240K104), suggesting it covers various tax types and service fees related to different aspects such as water (e.g., VA, V), waste (e.g., RESTAVFALL, KÄRL), and administrative fees.
+Naming Conventions:
+
+The strTaxekod uses a combination of letters and numbers which appear to follow specific conventions. For example:
+VA likely stands for water-related services.
+V might refer to specific types of water charges.
+K and S in the middle or end could indicate different types of containers or services (e.g., KÄRL for bins or containers, SÄCK for bags).
+Service Frequency:
+
+The tax descriptions often include numbers that seem to indicate the frequency of the service (e.g., 13 ggr/år, 52 ggr/år which translate to 13 times a year, 52 times a year). This provides insights into how often these services are billed or provided.
+Specific Services:
+
+Some codes are very specific, detailing particular services or scenarios (e.g., Slamtömning for sludge emptying, Sprinkleranläggning for sprinkler systems, Matavfall for food waste collection). This suggests the database is used for managing a detailed and comprehensive range of municipal services.
+Administrative and Miscellaneous Charges:
+
+There are entries for administrative tasks and other charges (e.g., ADMAVG for administrative fees, DRÖJRÄNTA for penalty interest). This indicates the table also includes financial penalties and additional service-related fees.
+Comprehensive Coverage:
+
+The table appears to comprehensively cover various aspects of municipal services including water supply, sewage, waste management, and administrative processes.
+Use Cases:
+
+Billing and Invoicing:
+
+The table can be used to generate bills and invoices for residents and businesses based on the services they use.
+Service Management:
+
+It helps in managing different municipal services, scheduling collections, and ensuring all provided services are documented and billed correctly.
+Reporting and Analysis:
+
+The table allows for detailed reporting and analysis of tax revenues, service usage, and operational efficiency of municipal services.
+Suggestions for Improvement:
+
+Normalization:
+
+If the database grows, consider normalizing the tables to reduce redundancy. For example, separate tables for service types, frequencies, and container types might help in managing the data more efficiently.
+Additional Fields:
+
+Adding fields such as effective_date and expiration_date for each tax code could help manage changes over time more effectively.
+Data Validation:
+
+Implement data validation rules to ensure the consistency and accuracy of the codes and descriptions.
+By understanding the structure and content of the tbFuTaxa table, one can better manage and utilize the database for municipal services and financial management.
 `
   if (brokenSql && sqlError) {
     return `

--- a/src/prompts/planAnswer.ts
+++ b/src/prompts/planAnswer.ts
@@ -254,6 +254,109 @@ CREATE TABLE tbFuAnlaggning (
 );
 \`\`\`
 
+Tables and Fields
+tbFuHandelse
+This table seems to record events or transactions related to facilities. Key fields include:
+
+recHandelse (int): Primary key, unique identifier for each event.
+intKundnr (int): Customer number, linking the event to a customer.
+strAnlnr (varchar): Facility number, linking the event to a facility.
+intTjanstnr (int): Service number, indicating the type of service.
+datDatumFrom and datDatumTom (datetime): Start and end dates of the event.
+strTaxekod (varchar): Tariff code, linking to the tariff table.
+lngFakturanr (bigint): Invoice number, linking the event to an invoice.
+Various other fields related to the event details, such as strRFID, strFordon, strAvvikelsekod, and strHandelseText.
+tbFuRenhAvvikelse
+This table records deviations or issues related to events.
+
+intRecnum (int): Primary key, unique identifier for each deviation.
+strAvvikelsekod (varchar): Deviation code, primary key.
+strAvvikelsetext (varchar): Text describing the deviation.
+Various boolean fields indicating different statuses and actions related to the deviation.
+tbFuTaxa
+This table contains tariff or pricing information.
+
+intRecnum (int): Primary key, unique identifier for each tariff.
+strTaxekod (varchar): Tariff code, primary key.
+strTaxebenamning (varchar): Tariff name.
+Various fields related to pricing, grouping, and applicability of the tariff.
+tbFuAnlaggning
+This table contains information about facilities.
+
+intRecnum (int): Primary key, unique identifier for each facility.
+strAnlnr (varchar): Facility number, primary key.
+intKundnr (int): Customer number, linking the facility to a customer.
+Various fields related to the address, categorization, and additional details of the facility.
+Relationships
+tbFuHandelse references tbFuAnlaggning through strAnlnr.
+tbFuHandelse references tbFuTaxa through strTaxekod.
+tbFuHandelse references tbFuRenhAvvikelse through strAvvikelsekod.
+Key Insights
+Facility Management: The tbFuAnlaggning table holds details about each facility, which are linked to events in tbFuHandelse.
+Event Tracking: The tbFuHandelse table is central to tracking all events, services, and transactions for each facility.
+Deviations Handling: The tbFuRenhAvvikelse table helps manage and document any issues or deviations related to events.
+Tariff Management: The tbFuTaxa table provides detailed tariff information, crucial for billing and pricing.
+
+Database Structure Analysis for tbFuTaxa
+
+The tbFuTaxa table in the provided database contains the following fields:
+
+strTaxekod:
+Description: This field likely represents the unique code or identifier for each tax type or service fee.
+Data Type: String
+Purpose: It serves as the primary key or unique identifier for each record in the table. It helps in distinguishing different types of taxes or service fees.
+strTaxebenamning:
+Description: This field describes the name or the details of the tax or service fee.
+Data Type: String
+Purpose: It provides a descriptive name for each tax type or service fee, allowing users to understand the nature of the fee or tax.
+Insights and Observations:
+
+Diversity of Tax Codes:
+
+The table contains a wide range of tax codes (e.g., 0001, 0002, 1101, 1201, 240K104), suggesting it covers various tax types and service fees related to different aspects such as water (e.g., VA, V), waste (e.g., RESTAVFALL, KÄRL), and administrative fees.
+Naming Conventions:
+
+The strTaxekod uses a combination of letters and numbers which appear to follow specific conventions. For example:
+VA likely stands for water-related services.
+V might refer to specific types of water charges.
+K and S in the middle or end could indicate different types of containers or services (e.g., KÄRL for bins or containers, SÄCK for bags).
+Service Frequency:
+
+The tax descriptions often include numbers that seem to indicate the frequency of the service (e.g., 13 ggr/år, 52 ggr/år which translate to 13 times a year, 52 times a year). This provides insights into how often these services are billed or provided.
+Specific Services:
+
+Some codes are very specific, detailing particular services or scenarios (e.g., Slamtömning for sludge emptying, Sprinkleranläggning for sprinkler systems, Matavfall for food waste collection). This suggests the database is used for managing a detailed and comprehensive range of municipal services.
+Administrative and Miscellaneous Charges:
+
+There are entries for administrative tasks and other charges (e.g., ADMAVG for administrative fees, DRÖJRÄNTA for penalty interest). This indicates the table also includes financial penalties and additional service-related fees.
+Comprehensive Coverage:
+
+The table appears to comprehensively cover various aspects of municipal services including water supply, sewage, waste management, and administrative processes.
+Use Cases:
+
+Billing and Invoicing:
+
+The table can be used to generate bills and invoices for residents and businesses based on the services they use.
+Service Management:
+
+It helps in managing different municipal services, scheduling collections, and ensuring all provided services are documented and billed correctly.
+Reporting and Analysis:
+
+The table allows for detailed reporting and analysis of tax revenues, service usage, and operational efficiency of municipal services.
+Suggestions for Improvement:
+
+Normalization:
+
+If the database grows, consider normalizing the tables to reduce redundancy. For example, separate tables for service types, frequencies, and container types might help in managing the data more efficiently.
+Additional Fields:
+
+Adding fields such as effective_date and expiration_date for each tax code could help manage changes over time more effectively.
+Data Validation:
+
+Implement data validation rules to ensure the consistency and accuracy of the codes and descriptions.
+By understanding the structure and content of the tbFuTaxa table, one can better manage and utilize the database for municipal services and financial management.
+
+
 Håll ditt svar under 300 tecken
 
 `

--- a/src/services/dbAccess.ts
+++ b/src/services/dbAccess.ts
@@ -65,14 +65,17 @@ export const getFullCustomerInfo = async (facilityRecnum: number) => {
   }
 }
 
+type Role = 'assistant' | 'user' | 'system'
+
 export const addReplyToThread = async (
   threadChannelId: string,
-  reply: string
+  reply: string,
+  role: Role = 'assistant'
 ) => {
   const redisClient = await redis.getClient()
   const res = await redisClient.rPush(
     `${redisPrefixes.threadReplies}:${threadChannelId}`,
-    reply
+    JSON.stringify({ role, content: reply })
   )
   await extendThreadLifeTime(threadChannelId)
   return res

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -1,0 +1,32 @@
+import config from '../config/openai'
+import OpenAI from 'openai'
+
+type AIRole = 'system' | 'user' | 'assistant'
+
+type AIMessage = {
+  role: AIRole
+  content: string
+}
+const openai = new OpenAI(config)
+export const createCompletion = async (
+  messages: AIMessage[],
+  model = 'gpt-4o'
+) => {
+  try {
+    const stream = await openai.chat.completions.create({
+      messages,
+      model,
+      stream: true,
+    })
+    let response = ''
+    for await (const part of stream) {
+      response += part.choices[0]?.delta?.content || ''
+    }
+
+    console.log(response)
+    return response
+  } catch (error) {
+    console.error('Error in createCompletion: ', error)
+    return error
+  }
+}

--- a/src/workers/answerQuestion.ts
+++ b/src/workers/answerQuestion.ts
@@ -2,6 +2,7 @@ import { Worker, Job } from 'bullmq'
 import discord from '../services/discord'
 import { TextChannel } from 'discord.js'
 import {
+  addReplyToThread,
   getFacilityThreadByThreadChannelId,
   getThreadContents,
 } from '../services/dbAccess'
@@ -47,8 +48,8 @@ const worker = new Worker(
           },
         ],
         false,
-        512,
-        'open-mixtral-8x22b'
+        2048
+        // , 'open-mixtral-8x22b'
       )
       clearInterval(typingHandle)
       if (sqlQueryResponse) {
@@ -58,8 +59,13 @@ const worker = new Worker(
             break
           case 'chat.completion':
             const answer = sqlQueryResponse.choices?.[0]?.message?.content
+            if (!answer) {
+              console.log(JSON.stringify(sqlQueryResponse, null, 2))
+              throw new Error('No answer in completion')
+            }
             console.log('## MISTRAL ANSWER: ', answer)
             await msg.edit(answer)
+            await addReplyToThread(thread.id, answer, 'assistant')
             break
           default:
             msg.edit(
@@ -67,6 +73,7 @@ const worker = new Worker(
             )
             job.log('Unhandled response from Mistral:')
             job.log(JSON.stringify(sqlQueryResponse, null, 2))
+            throw new Error('Unhandled response from Mistral')
         }
       }
 

--- a/src/workers/answerQuestion.ts
+++ b/src/workers/answerQuestion.ts
@@ -33,7 +33,7 @@ const worker = new Worker(
         thread.sendTyping()
       }, 8000)
 
-      const systemPrompt = prompt(results, plan, sql, distilledQuestion)
+      const systemPrompt = prompt(results, plan, sql)
       console.log('## MISTRAL PROMPT: ', systemPrompt, distilledQuestion)
       const sqlQueryResponse = await createCompletion(
         [

--- a/src/workers/dataFetcher.ts
+++ b/src/workers/dataFetcher.ts
@@ -7,6 +7,7 @@ import redis from '../config/redis'
 import sqlPrompt from '../prompts/generateCustomerInfoSQL'
 import { answerQuestion, dataFetcher } from '../queues'
 import { createCompletion } from '../services/openai'
+import { resultToCsv } from '../lib/resultToCsv'
 
 class JobData extends Job {
   data: {
@@ -173,6 +174,8 @@ const worker = new Worker(
           results: 'Inga resultat hittades från databasen',
         })
       } else {
+        const csv = resultToCsv(results)
+
         msg.edit('Översätter resultat...')
         answerQuestion.add('answer in thread ' + threadChannelId, {
           threadChannelId,
@@ -181,7 +184,7 @@ const worker = new Worker(
           distilledQuestion,
           plan,
           sql,
-          results: JSON.stringify(results, null, 2),
+          results: csv,
         })
       }
       return { sql, distilledQuestion, plan, results }

--- a/src/workers/handleCommandSamtal.ts
+++ b/src/workers/handleCommandSamtal.ts
@@ -33,6 +33,7 @@ const worker = new Worker(
         )
       } else if (possibleCustomers.length === 1) {
         const initialResponse = `1 anläggning hittades med anläggningsnummer (${strAnlNr})`
+
         message.edit(initialResponse)
         // const fullCustomerInfo = await getFullCustomerInfo(possibleCustomers[0].intRecnum)
         const threadStart = new Date()
@@ -61,15 +62,16 @@ const worker = new Worker(
           `Thread called '${name}' created: '${thread.id} with message '${messageId}`
         )
         await thread.sendTyping()
-        const reply = `Kundens namn: \`${possibleCustomers[0].strKundNamnHel}\`
+        const customerCard = `Kundens namn: \`${possibleCustomers[0].strKundNamnHel}\`
 Adress: \`${possibleCustomers[0].strAnlAdressHel}\`
 Fastighetsbeteckning: \`${possibleCustomers[0].strFastBeteckningHel}\`
 KundNummer: \`${possibleCustomers[0].intKundnr}\`
 Anläggningsnummer: \`${possibleCustomers[0].strAnlnr}\``
 
         await addThread(thread.id, possibleCustomers[0].strAnlnr)
-        await addReplyToThread(thread.id, reply)
-        const res = await thread.send(reply)
+        await addReplyToThread(thread.id, initialResponse, 'assistant')
+        await addReplyToThread(thread.id, customerCard, 'assistant')
+        const res = await thread.send(customerCard)
       } else {
         let msg = `${possibleCustomers.length} anläggningar hittades`
         possibleCustomers.forEach((facility, index) => {

--- a/src/workers/handleCommandSamtal.ts
+++ b/src/workers/handleCommandSamtal.ts
@@ -45,11 +45,18 @@ const worker = new Worker(
           })
           .replace(',', '')
         const name = `${threadStart} — ${possibleCustomers[0].strFastBeteckningHel}`
-        const thread = await channel.threads.create({
+        let thread = await channel.threads.create({
           name: name,
           autoArchiveDuration: 1440,
           startMessage: messageId,
         })
+        if (!thread.id) {
+          thread = await channel.threads.create({
+            name: name,
+            autoArchiveDuration: 1440,
+            startMessage: messageId,
+          })
+        }
         console.log(
           `Thread called '${name}' created: '${thread.id} with message '${messageId}`
         )

--- a/src/workers/handleReply.ts
+++ b/src/workers/handleReply.ts
@@ -40,7 +40,7 @@ const worker = new Worker(
           return false
         }
 
-        await addReplyToThread(threadChannelId, reply)
+        await addReplyToThread(threadChannelId, reply, 'user')
         const msg = await thread.send('Sparar frågan...')
         summarizeAsk.add('answer reply in thread ' + threadChannelId, {
           threadChannelId,

--- a/src/workers/handleReply.ts
+++ b/src/workers/handleReply.ts
@@ -1,4 +1,5 @@
 import { Worker, Job } from 'bullmq'
+import discordConfig from '../config/discord'
 import discord from '../services/discord'
 import { TextChannel } from 'discord.js'
 import {
@@ -21,13 +22,24 @@ const worker = new Worker(
     const { threadChannelId, reply } = job.data
     try {
       job.log(`handleReply: ${reply}`)
+
       const thread = (await discord.channel(threadChannelId)) as TextChannel
       thread.sendTyping()
 
       const threadModel = await getFacilityThreadByThreadChannelId(
         threadChannelId
       )
+
       if (threadModel) {
+        const mentions = gatherMentions(reply)
+        if (
+          mentions.length > 0 &&
+          !mentions.includes(discordConfig.botUserId)
+        ) {
+          thread.send('Tolkar inte detta som en fråga till mig...')
+          return false
+        }
+
         await addReplyToThread(threadChannelId, reply)
         const msg = await thread.send('Sparar frågan...')
         summarizeAsk.add('answer reply in thread ' + threadChannelId, {
@@ -52,5 +64,27 @@ const worker = new Worker(
     autorun: false,
   }
 )
+
+const gatherMentions = (reply: string): string[] => {
+  const regex = new RegExp('<@(?<userid>\\d+)>', 'gm')
+
+  const result: string[] = []
+  let m
+
+  while ((m = regex.exec(reply)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++
+    }
+
+    // The result can be accessed through the `m`-variable.
+    m.forEach((match, groupIndex) => {
+      if (groupIndex === 1) {
+        result.push(match)
+      }
+    })
+  }
+  return result
+}
 
 export default worker

--- a/src/workers/summarizeAsk.ts
+++ b/src/workers/summarizeAsk.ts
@@ -39,16 +39,9 @@ const worker = new Worker(
         )}\n#################\n\n`
       )
 
-      const partThread = JSON.stringify([
-        `Kundens anläggningsnummer (strAnlNr): ${strAnlNr}`,
-        `Kundens anläggningsnummer (strAnlNr): ${strAnlNr}`,
-        `Kundens anläggningsnummer (strAnlNr): ${strAnlNr}`,
-        fullThread[fullThread.length - 1],
-      ])
-
       console.log(
         `\n\n#################\n${JSON.stringify(
-          partThread,
+          fullThread,
           null,
           2
         )}\n#################\n\n`
@@ -61,7 +54,7 @@ const worker = new Worker(
         },
         {
           role: 'user',
-          content: partThread,
+          content: JSON.stringify(fullThread),
         },
       ])
       clearInterval(typingHandle)


### PR DESCRIPTION
- Generate SQL with OpenAI instead of Mistral.
- Only answer in thread when mentioned or noone is mentioned.
- Convert SQL results to CSV rather than JSON to keep token count low in queries.
- Allow the bot to answer with tabular data when needed.
- Add faktura table DDL to give slightly larger scope to ask questions about
- Add a Open AI analysis of the database structure to better align the column names with their descriptions and therefor the questions wordspace.
- Keep track of who posts a certain message in a thread so it becomes clearer for assistant when including the entire thread what are follow-up questions rather than new questions without relation to earlier asked questions.
- Allow answerQuestions AI reply to cost 2048 tokens to be able to fit tabular data.
- Avoid infinite retryloop